### PR TITLE
Parse json in responses

### DIFF
--- a/backbone.fetch.js
+++ b/backbone.fetch.js
@@ -31,6 +31,7 @@
   var ajax = function(options) {
     if (options.type === 'GET' && typeof options.data === 'object') {
       options.url = stringifyGETParams(options.url, options.data);
+      delete options.data;
     }
 
     return fetch(options.url, defaults(options, {

--- a/backbone.fetch.js
+++ b/backbone.fetch.js
@@ -14,7 +14,7 @@
       if (obj[prop] === undefined) obj[prop] = source[prop];
     }
     return obj;
-  }
+  };
 
   var stringifyGETParams = function(url, data) {
     var query = '';
@@ -26,7 +26,17 @@
     }
     if (query) url += (~url.indexOf('?') ? '&' : '?') + query.substring(1);
     return url;
-  }
+  };
+
+  var checkStatus = function(response) {
+    if (response.status >= 200 && response.status < 300) {
+      return response;
+    } else {
+      var error = new Error(response.statusText);
+      error.response = response;
+      throw error;
+    }
+  };
 
   var ajax = function(options) {
     if (options.type === 'GET' && typeof options.data === 'object') {
@@ -35,13 +45,18 @@
     }
 
     return fetch(options.url, defaults(options, {
-      method: options.type,
-      headers: defaults(options.headers || {}, {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      }),
-      body: options.data
-    })).then(options.success, options.error);
+        method: options.type,
+        headers: defaults(options.headers || {}, {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json'
+        }),
+        body: options.data
+      }))
+      .then(checkStatus)
+      .then(function(response) {
+        return options.dataType === 'json' ? response.json(): response.text();
+      })
+      .then(options.success, options.error);
   };
 
   if (typeof exports === 'object') {

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
   "devDependencies": {
     "backbone": "git://github.com/jashkenas/backbone#cbaa8d144b7560d2b509c1ffbaf6ddb1e3829e6c",
     "chai": "^1.9.1",
-    "fetch": "git://github.com/github/fetch",
     "mocha": "^1.21.4",
     "sinon": "^1.10.3",
     "underscore": "^1.6.0",
+    "whatwg-fetch": "^0.9.0",
     "xmlhttprequest": "^1.6.0"
   }
 }

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -6,9 +6,9 @@ require('sinon/lib/sinon/util/event');
 require('sinon/lib/sinon/util/fake_xml_http_request');
 
 (function() {
-  if (typeof window === 'undefined') global.window = {};
-  require('fetch');
-  global.fetch = sinon.spy(window.fetch);
+  if (typeof window === 'undefined') global.self = {};
+  require('whatwg-fetch');
+  global.fetch = sinon.spy(self.fetch);
 })();
 
 XMLHttpRequest = function() {}


### PR DESCRIPTION
`Backbone.sync` expects a parsed result in arguments of `success` function.
Without it you cannot properly create models and fill collection.

I made some things for it:
- rename `fetch` module because it has been renamed in https://github.com/github/fetch/commit/01797bceb6e07d0a0b2090915c4cd0df52f7bb5d
- do not set body for GET-requests, because `fetch` specs doesn't allow it: https://github.com/github/fetch/blob/master/fetch.js#L214
- parse response status code, because otherwise all finished requests would be resolved despite on status code of response
- read dataType option. It comes from [jQuery.ajax](http://api.jquery.com/jQuery.ajax/#jQuery-ajax-settings) and Backbone sets it and expect object in response
- write test on it. Note that I found better solution to make `sinon.fakeServer` work in node.js
