### PR TITLE
Can't catch error

### DIFF
--- a/backbone.fetch.js
+++ b/backbone.fetch.js
@@ -56,7 +56,11 @@
       .then(function(response) {
         return options.dataType === 'json' ? response.json(): response.text();
       })
-      .then(options.success, options.error);
+      .then(options.success)
+      .catch(function(e) {
+        options.error(e);
+        throw e;
+      });
   };
 
   if (typeof exports === 'object') {

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -129,17 +129,32 @@ describe('backbone.fetch', function() {
       return promise;
     });
 
-    it('should invoke the error callback on error', function() {
+    it('should invoke the error callback on error', function(done) {
       var promise = ajax({
         url: 'test',
         type: 'GET',
-        success: function(response) { 
-          throw new Error('this reqest should be failed');
+        success: function(response) {
+          throw new Error('this request should be failed');
         },
         error: function(error) {
           expect(error.response.status).to.equal(400);
         }
       });
+
+      promise.then(function() {
+        throw new Error('this request should be failed');
+      }).catch(function(error) {
+        if (error.response) {
+          expect(error.response.status).to.equal(400);
+        }
+        else {
+          throw error;
+        }
+        done();
+      }).catch(function(error) {
+        done(error);
+      });
+
       server.respond([400, {}, 'Server error']);
       return promise;
     });


### PR DESCRIPTION
Related to bug #2 

Hi,

I try to use this in my project, but i have a problem :

When i use like this :

```
object.fetch(options).then(function () {
   ...
}).catch(function () {
  ...
});
```

catch (on error, ie: 401) is never called because, the line .then(options.success, options.error) process the error.
So the error is considered as managed and the method then is called instead of catch.

I think that we should call options.error in a method a re-trigger the the exception.
