### PR TITLE
The `error` callback should not be required

### DIFF
--- a/backbone.fetch.js
+++ b/backbone.fetch.js
@@ -58,7 +58,9 @@
       })
       .then(options.success)
       .catch(function(e) {
-        options.error(e);
+        if (options.error) {
+          options.error(e);
+        }
         throw e;
       });
   };

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -159,6 +159,32 @@ describe('backbone.fetch', function() {
       return promise;
     });
 
+    it('should not fail without error callback', function(done) {
+      var promise = ajax({
+        url: 'test',
+        type: 'GET',
+        success: function(response) {
+          throw new Error('this request should be failed');
+        }
+      });
+
+      promise.then(function() {
+        throw new Error('this request should be failed');
+      }).catch(function(error) {
+        if (error.response) {
+          expect(error.response.status).to.equal(400);
+        }
+        else {
+          throw error;
+        }
+        done();
+      }).catch(function(error) {
+        done(error);
+      });
+
+      server.respond([400, {}, 'Server error']);
+      return promise;
+    });
   });
 
   describe('Promise', function() {


### PR DESCRIPTION
It should also be possible to catch failures with promises.
