### PR TITLE
Parse json body for failed request

### DIFF
--- a/backbone.fetch.js
+++ b/backbone.fetch.js
@@ -59,9 +59,13 @@
         return options.dataType === 'json' ? response.json(): response.text();
       })
       .then(options.success)
-      .catch(function(e) {
-        if (options.error) options.error(e);
-        throw e;
+      .catch(function(error) {
+        var promise = options.dataType === 'json' ? error.response.json() : error.response.text();
+        return promise.then(function(responseData) {
+          error.responseData = responseData;
+          if (options.error) options.error(error);
+          throw error;
+        });
       });
   };
 

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -175,6 +175,46 @@ describe('backbone.fetch', function() {
       server.respond([400, {}, 'Server error']);
       return promise;
     });
+
+    it('should parse json as property of Error on failing request', function(done) {
+        var promise = ajax({
+            dataType: 'json',
+            url: 'test',
+            type: 'GET',
+        });
+
+        promise.then(function() {
+            throw new Error('this request should fail');
+        }).catch(function(error) {
+            expect(error.responseData).to.deep.equal({ code: 'INVALID_HORSE' });
+            done();
+        }).catch(function(error) {
+            done(error);
+        });
+
+        server.respond([400, {}, JSON.stringify({ code: 'INVALID_HORSE' })]);
+        return promise;
+    });
+
+    it('should parse text as property of Error on failing request', function(done) {
+        var promise = ajax({
+            dataType: 'text',
+            url: 'test',
+            type: 'GET',
+        });
+
+        promise.then(function() {
+            throw new Error('this request should fail');
+        }).catch(function(error) {
+            expect(error.responseData).to.equal('Nope');
+            done();
+        }).catch(function(error) {
+            done(error);
+        });
+
+        server.respond([400, {}, 'Nope']);
+        return promise;
+    });
   });
 
   describe('Promise', function() {


### PR DESCRIPTION
When a server sends a non-2xx response, you often want to interpret the body and do something based on a specific error code. This should make that possible by adding a `responseData` property to the Error.

This is a bit hacky, but using`response.json()` is not possible here (I think), because then you would need to resolve `response.json()` and then throw the error.

I couldn't find a cleaner solution after debugging this for hours.
