### PR TITLE
Fix undefined error on network error

### DIFF
--- a/backbone.fetch.js
+++ b/backbone.fetch.js
@@ -60,12 +60,15 @@
       })
       .then(options.success)
       .catch(function(error) {
-        var promise = options.dataType === 'json' ? error.response.json() : error.response.text();
-        return promise.then(function(responseData) {
-          error.responseData = responseData;
-          if (options.error) options.error(error);
-          throw error;
-        });
+        if (error.response) {
+          var promise = options.dataType === 'json' ? error.response.json() : error.response.text();
+          return promise.then(function(responseData) {
+            error.responseData = responseData;
+            if (options.error) options.error(error);
+            throw error;
+          });
+        }
+        throw error;
       });
   };
 


### PR DESCRIPTION
When a request fails due to a network error, the Error object will not have a `response` property.

An example:

``` js
Backbone.ajax({
  type: 'GET',
  dataType: 'json',
  url: `non-existent-api.com`,
}).catch(function(err) {
  console.log(err); // TypeError: Cannot read property 'json' of undefined
})
```

With this fix it will output `TypeError: Network request failed`.

I tried adding a test for this, but couldn't figure out how to fake a network error. Do you have any idea?

PS: Sorry for the PR burst, this will probably be the last one for a while ;).
