### PR TITLE
fix: add head, 204 parser handling

### DIFF
--- a/backbone.fetch.js
+++ b/backbone.fetch.js
@@ -29,7 +29,7 @@
   };
 
   var getData = function(response, dataType) {
-    return dataType === 'json' ? response.json() : response.text();
+    return dataType === 'json' && response.status !== 204 ? response.json() : response.text();
   };
 
   var ajax = function(options) {
@@ -49,7 +49,9 @@
 
     return fetch(options.url, options)
       .then(function(response) {
-        var promise = getData(response, options.dataType);
+        var promise = options.type === 'HEAD'
+          ? Promise.resolve(null)
+          : getData(response, options.dataType);
 
         if (response.ok) return promise;
 

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -178,6 +178,38 @@ describe('backbone.fetch', function() {
       return promise;
     });
 
+    it('should produce an error for invalid json', function(done) {
+      var promise = ajax({
+        dataType: 'json',
+        url: 'test',
+        type: 'GET',
+      });
+
+      promise.then(function() {
+          throw new Error('this request should fail');
+      }).catch(function(error) {
+          expect(error).to.be.an.instanceof(SyntaxError);
+          expect(error).not.to.have.property('response');
+          done();
+      }).catch(function(error) {
+          done(error);
+      });
+
+      server.respond([200, {}, '']);
+      return promise;
+    });
+
+    it('should not parse json for 204 responses', function() {
+      var promise = ajax({
+        dataType: 'json',
+        url: 'test',
+        type: 'GET',
+      });
+
+      server.respond([204, {}, '']);
+      return promise;
+    });
+
     it('should parse json as property of Error on failing request', function(done) {
       var promise = ajax({
           dataType: 'json',


### PR DESCRIPTION
This behavior improves jquery compatibility. In particular, this means that a 204 response with default params won't raise a `SyntaxError`.

See https://github.com/jquery/jquery/blob/df6858df2ed3fc5c424591a5e09b900eb4ce0417/src/ajax.js#L762-L780